### PR TITLE
Fix code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/Backend/app/utils/custom_decorators/json_schema_validator.py
+++ b/Backend/app/utils/custom_decorators/json_schema_validator.py
@@ -24,10 +24,10 @@ def validate_schema(schema_name):
                 jsonschema.validate(instance=json_data, schema=schema_name)
             except jsonschema.exceptions.ValidationError as e:
                 logging.info(f"Json schema validation error: {e}")
-                return jsonify({"response": "Invalid JSON data.", "error": str(e)}), 400
+                return jsonify({"response": "Invalid JSON data."}), 400
             except Exception as e:
                 logging.info(f"Request rejected by schema validation: {e}")
-                return jsonify({"response": "Request should be a valid JSON.", "error": str(e)}), 400
+                return jsonify({"response": "Request should be a valid JSON."}), 400
             return f(*args, **kw)
         return wrapper
     return decorator


### PR DESCRIPTION
Fixes [https://github.com/Eldritchy/secure_register_and_login_python/security/code-scanning/3](https://github.com/Eldritchy/secure_register_and_login_python/security/code-scanning/3)

To fix the problem, we need to modify the code to ensure that detailed error messages are not exposed to the user. Instead, we should log the detailed error messages on the server and return a generic error message to the user. This can be achieved by removing the exception message from the JSON response and only including a generic error message.

1. Modify the `validate_schema` decorator function to log the detailed error messages on the server and return a generic error message to the user.
2. Update the `return` statements in the `except` blocks to remove the exception message from the JSON response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
