### PR TITLE
Fix code scanning alert no. 12: Information exposure through an exception

### DIFF
--- a/Backend/app/routes/admin/user_action/routes.py
+++ b/Backend/app/routes/admin/user_action/routes.py
@@ -327,9 +327,9 @@ def admin_delete_user():
         db.session.rollback()
         logging.error(f"DB integrity error prevented user deletion: {e}")
         log_event("ADMIN_DELETE_USER","deletion problem",user.id)
-        return jsonify({"response": "Error deleting user", "error": str(e)}), 500
+        return jsonify({"response": "Error deleting user"}), 500
 
     except Exception as e:
         logging.error(f"Error prevented user deletion: {e}")
         log_event("ADMIN_DELETE_USER","deletion problem",user.id)
-        return jsonify({"response": "Error deleting user", "error": str(e)}), 500
+        return jsonify({"response": "Error deleting user"}), 500


### PR DESCRIPTION
Fixes [https://github.com/Eldritchy/secure_register_and_login_python/security/code-scanning/12](https://github.com/Eldritchy/secure_register_and_login_python/security/code-scanning/12)

To fix the problem, we need to ensure that detailed error information is not exposed to the user. Instead, we should log the detailed error information on the server side and return a generic error message to the user. This can be achieved by modifying the exception handling blocks to remove the detailed error message from the JSON response.

1. In the `admin_delete_user` function, update the `except` blocks to log the detailed error information and return a generic error message.
2. Ensure that the logging and event logging mechanisms capture the necessary details for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
