### PR TITLE
Fix code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/Backend/app/utils/custom_decorators/json_schema_validator.py
+++ b/Backend/app/utils/custom_decorators/json_schema_validator.py
@@ -27,7 +27,7 @@ def validate_schema(schema_name):
                 return jsonify({"response": "Invalid JSON data.", "error": str(e)}), 400
             except Exception as e:
                 logging.info(f"Request rejected by schema validation: {e}")
-                return jsonify({"response": "Request should be a valid JSON.", "error": str(e)}), 400
+                return jsonify({"response": "Request should be a valid JSON.", "error": "An internal error has occurred."}), 400
             return f(*args, **kw)
         return wrapper
     return decorator


### PR DESCRIPTION
Fixes [https://github.com/Eldritchy/secure_register_and_login_python/security/code-scanning/4](https://github.com/Eldritchy/secure_register_and_login_python/security/code-scanning/4)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the JSON response to exclude the detailed exception message.

- Replace the detailed error message in the JSON response with a generic error message.
- Ensure that the detailed error message is logged on the server for debugging purposes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
