### PR TITLE
Fix code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/Backend/app/routes/admin/user_action/routes.py
+++ b/Backend/app/routes/admin/user_action/routes.py
@@ -88,7 +88,7 @@ def change_user_flag():
             log_event("ADMIN_FLAG_USER","flag change problem",0, f"User id {user_id}, integrity error raised.")
         except Exception as e:
             logging.error(f"Error prevented user flag change log to be saved: {e}")
-        return jsonify({"response": "Error changing user flag - integrity error", "error": str(e)}), 500
+        return jsonify({"response": "Error changing user flag - integrity error"}), 500
     
     except Exception as e:
         logging.error(f"Error prevented user flag change: {e}")
@@ -96,7 +96,7 @@ def change_user_flag():
             log_event("ADMIN_FLAG_USER","flag change problem",0, f"User id {user_id}, error raised.")
         except Exception as e:
             logging.error(f"Error prevented user flag change log to be saved: {e}")
-        return jsonify({"response": "Error changing user flag", "error": str(e)}), 500
+        return jsonify({"response": "Error changing user flag"}), 500
     
 # ----- ACTION: CHANGE USER ACCESS TYPE -----
 @user_action.route("/access_change", methods=["POST"])


### PR DESCRIPTION
Fixes [https://github.com/Eldritchy/secure_register_and_login_python/security/code-scanning/6](https://github.com/Eldritchy/secure_register_and_login_python/security/code-scanning/6)

To fix the problem, we need to ensure that detailed error information is not exposed to the end user. Instead, we should log the detailed error information on the server and return a generic error message to the user. This can be achieved by modifying the exception handling blocks to log the error and return a generic message.

1. Modify the exception handling blocks to log the detailed error information.
2. Return a generic error message to the user without including the exception details.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
