### PR TITLE
Fix code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/Backend/app/routes/admin/user_action/routes.py
+++ b/Backend/app/routes/admin/user_action/routes.py
@@ -171,7 +171,7 @@ def change_user_access():
             log_event("ADMIN_USER_ACCESS_CHANGE","access change problem",0, f"User id {user_id}, integrity error raised.")
         except Exception as e:
             logging.error(f"Error prevented user access change log to be saved: {e}")
-        return jsonify({"response": "Error deleting user", "error": str(e)}), 500
+        return jsonify({"response": "Error deleting user"}), 500
     
     except Exception as e:
         logging.error(f"Error prevented user type change: {e}")
@@ -179,7 +179,7 @@ def change_user_access():
             log_event("ADMIN_USER_ACCESS_CHANGE","access change problem",0, f"User id {user_id}, error raised.")
         except Exception as e:
             logging.error(f"Error prevented user access change log to be saved: {e}")
-        return jsonify({"response": "Error changing user type", "error": str(e)}), 500
+        return jsonify({"response": "Error changing user type"}), 500
 
 
 # ----- ACTION: BLOCK/UNBLOCK -----


### PR DESCRIPTION
Fixes [https://github.com/Eldritchy/secure_register_and_login_python/security/code-scanning/8](https://github.com/Eldritchy/secure_register_and_login_python/security/code-scanning/8)

To fix the problem, we need to ensure that detailed error information is not exposed to the user. Instead, we should log the detailed error information on the server and return a generic error message to the user. This can be achieved by modifying the exception handling blocks to remove the detailed error message from the response.

1. Modify the exception handling blocks to log the detailed error information on the server.
2. Return a generic error message to the user without including the exception details.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
