### PR TITLE
Fix code scanning alert no. 9: Information exposure through an exception

### DIFF
--- a/Backend/app/routes/admin/user_action/routes.py
+++ b/Backend/app/routes/admin/user_action/routes.py
@@ -247,7 +247,7 @@ def block_unblock_user():
             log_event("ADMIN_BLOCK_USER","block problem",user.id)
         else:
             log_event("ADMIN_BLOCK_USER","unblock problem",user.id)
-        return jsonify({"response": "Error deleting user", "error": str(e)}), 500
+        return jsonify({"response": "Error deleting user"}), 500
     
     except Exception as e:
         logging.error(f"Error prevented user block/unblock: {e}")
@@ -255,7 +255,7 @@ def block_unblock_user():
             log_event("ADMIN_BLOCK_USER","block problem",user.id)
         else:
             log_event("ADMIN_BLOCK_USER","unblock problem",user.id)
-        return jsonify({"response": "Error blocking/unblocking user", "error": str(e)}), 500
+        return jsonify({"response": "Error blocking/unblocking user"}), 500
     
 
 # ----- ACTION: DELETE USER -----


### PR DESCRIPTION
Fixes [https://github.com/Eldritchy/secure_register_and_login_python/security/code-scanning/9](https://github.com/Eldritchy/secure_register_and_login_python/security/code-scanning/9)

To fix the problem, we need to ensure that detailed error information is not exposed to the user. Instead, we should log the detailed error information on the server side and return a generic error message to the user. This can be achieved by modifying the exception handling blocks to log the error details and return a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
