### PR TITLE
Fix code scanning alert no. 10: Information exposure through an exception

### DIFF
--- a/Backend/app/routes/admin/user_action/routes.py
+++ b/Backend/app/routes/admin/user_action/routes.py
@@ -247,7 +247,7 @@ def block_unblock_user():
             log_event("ADMIN_BLOCK_USER","block problem",user.id)
         else:
             log_event("ADMIN_BLOCK_USER","unblock problem",user.id)
-        return jsonify({"response": "Error deleting user", "error": str(e)}), 500
+        return jsonify({"response": "Error deleting user", "error": "An internal error has occurred."}), 500
     
     except Exception as e:
         logging.error(f"Error prevented user block/unblock: {e}")
@@ -255,7 +255,7 @@ def block_unblock_user():
             log_event("ADMIN_BLOCK_USER","block problem",user.id)
         else:
             log_event("ADMIN_BLOCK_USER","unblock problem",user.id)
-        return jsonify({"response": "Error blocking/unblocking user", "error": str(e)}), 500
+        return jsonify({"response": "Error blocking/unblocking user", "error": "An internal error has occurred."}), 500
     
 
 # ----- ACTION: DELETE USER -----


### PR DESCRIPTION
Fixes [https://github.com/Eldritchy/secure_register_and_login_python/security/code-scanning/10](https://github.com/Eldritchy/secure_register_and_login_python/security/code-scanning/10)

To fix the problem, we should replace the detailed error message with a generic one before sending it to the user. The detailed error message should be logged on the server for debugging purposes. This way, we prevent sensitive information from being exposed to the user while still retaining the ability to diagnose issues.

- Replace the detailed error message in the JSON response with a generic message.
- Ensure that the detailed error message is logged on the server.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
